### PR TITLE
(feat): add Blade view templates for fairs and entrepreneurs (index, create, edit & shared _form partial)

### DIFF
--- a/resources/views/entrepreneurs/_form.blade.php
+++ b/resources/views/entrepreneurs/_form.blade.php
@@ -1,0 +1,28 @@
+@php($readonly = $readonly ?? false)
+
+<div class="space-y-4">
+  <div>
+    <label class="block text-gray-300 mb-1">Nombre</label>
+    <input type="text" name="nombre" value="{{ old('nombre', '') }}" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2" placeholder="e.g. Alan Smithee"/>
+  </div>
+
+  <div>
+    <label class="block text-gray-300 mb-1">Teléfono</label>
+    <input type="tel" name="telefono" value="{{ old('telefono', '') }}" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2" placeholder="e.g. 8888-8888"/>
+  </div>
+
+  <div>
+    <label class="block text-gray-300 mb-1">Rubro</label>
+    <input type="text" name="rubro" value="{{ old('rubro', '') }}" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2" placeholder="e.g. Comida artesanal"/>
+  </div>
+
+  <div>
+    <label class="block text-gray-300 mb-1">Ferias</label>
+    <select name="ferias[]" multiple class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2">
+      <!-- Ejemplo temporal de opciones -->
+      <option value="1">Feria de Artesanías</option>
+      <option value="2">Feria de Tecnología</option>
+      <option value="3">Feria de Alimentos</option>
+    </select>
+  </div>
+</div>

--- a/resources/views/entrepreneurs/create.blade.php
+++ b/resources/views/entrepreneurs/create.blade.php
@@ -1,0 +1,23 @@
+{{-- resources/views/entrepreneurs/create.blade.php --}}
+@extends('layouts.app')
+
+@section('content')
+<div class="bg-slate-800 min-h-screen px-20 py-8">
+    <h1 class="text-2xl font-semibold text-gray-100 mb-6">
+        {{ __('Registrar nuevo emprendedor') }}
+    </h1>
+
+    <form action="#" method="POST" class="bg-gray-900 shadow-lg rounded-lg p-6 space-y-6">
+        @include('entrepreneurs._form')
+
+        <div class="flex items-center justify-end gap-2">
+          <button type="submit" class="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500 transition duration-200">
+              <i class="fa-solid fa-check mr-1"></i> {{ __('Guardar') }}
+          </button>
+          <a href="{{ route('entrepreneurs.index') }}" class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 transition duration-200">
+              <i class="fa-solid fa-xmark mr-1"></i> {{ __('Cancelar') }}
+          </a>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/entrepreneurs/edit.blade.php
+++ b/resources/views/entrepreneurs/edit.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="bg-slate-800 min-h-screen px-20 py-8">
+  <h1 class="text-2xl font-semibold text-gray-100 mb-6">
+    Editar Emprendedor
+  </h1>
+
+  <form action="#" method="POST" class="bg-gray-900 shadow-lg rounded-lg p-6 space-y-6">
+    @csrf
+    @method('PUT')
+
+    <div class="space-y-4">
+      <div>
+        <label class="block text-gray-300 mb-1">Nombre</label>
+        <input type="text" name="nombre"
+               value="Juan Pérez"
+               class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2"/>
+      </div>
+
+      <div>
+        <label class="block text-gray-300 mb-1">Teléfono</label>
+        <input type="text" name="telefono"
+               value="8888-1234"
+               class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2"/>
+      </div>
+
+      <div>
+        <label class="block text-gray-300 mb-1">Rubro</label>
+        <input type="text" name="rubro"
+               value="Artesanías"
+               class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2"/>
+      </div>
+
+      <div>
+        <label class="block text-gray-300 mb-1">Ferias</label>
+        <select name="ferias[]" multiple
+                class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2">
+          <option value="1" selected>Feria de Artesanías</option>
+          <option value="2" selected>Feria de Comida</option>
+          <option value="3">Feria de Tecnología</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-end gap-2">
+      <button type="submit"
+              class="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500 transition">
+        Actualizar
+      </button>
+      <a href="#"
+         class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 transition">
+        Cancelar
+      </a>
+    </div>
+  </form>
+</div>
+@endsection

--- a/resources/views/entrepreneurs/index.blade.php
+++ b/resources/views/entrepreneurs/index.blade.php
@@ -1,0 +1,91 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="bg-slate-800 min-h-screen px-20 py-8">
+    <h1 class="text-2xl font-semibold text-gray-100 mb-6">
+        {{ __('Emprendedores registrados') }}
+    </h1>
+
+    <a href="{{ route('entrepreneurs.create') }}"
+       class="mb-4 inline-block px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500 transition duration-200">
+        <i class="fa-solid fa-plus mr-2"></i>
+        {{ __('Nuevo emprendedor') }}
+    </a>
+
+    <div class="overflow-x-auto bg-gray-900 shadow-lg rounded-lg">
+        <table class="min-w-full divide-y divide-gray-800">
+            <thead class="bg-gray-800 text-gray-300">
+                <tr>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Nombre</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Teléfono</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Rubro</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Ferias</th>
+                    <th class="px-4 py-3 text-center text-sm font-semibold">Acciones</th>
+                </tr>
+            </thead>
+            <tbody class="bg-gray-900 divide-y divide-gray-800">
+                <!-- Ejemplo de fila 1 -->
+                <tr class="even:bg-gray-800">
+                    <td class="px-6 py-4 text-gray-300">Juan Pérez</td>
+                    <td class="px-6 py-4 text-gray-300">8888-1234</td>
+                    <td class="px-6 py-4 text-gray-300">Artesanías</td>
+                    <td class="px-6 py-4 text-gray-300">
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs mr-1">
+                            Feria de Artesanías
+                        </span>
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs">
+                            Feria de Comida
+                        </span>
+                    </td>
+                    <td class="px-4 py-4">
+                        <div class="flex flex-col md:flex-row items-center justify-center gap-2">
+                            <a href="#" title="Ver"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-teal-600 text-white hover:bg-teal-500 transition">
+                                <i class="fas fa-eye text-sm"></i>
+                            </a>
+                            <a href="{{ route('entrepreneurs.edit') }}" title="Editar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-yellow-500 text-white hover:bg-yellow-400 transition">
+                                <i class="fas fa-pen text-sm"></i>
+                            </a>
+                            <a href="#" title="Eliminar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-red-500 text-white hover:bg-red-400 transition">
+                                <i class="fas fa-trash text-sm"></i>
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+                <!-- Ejemplo de fila 2 -->
+                <tr>
+                    <td class="px-6 py-4 text-gray-300">María López</td>
+                    <td class="px-6 py-4 text-gray-300">7777-5678</td>
+                    <td class="px-6 py-4 text-gray-300">Comida artesanal</td>
+                    <td class="px-6 py-4 text-gray-300">
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs mr-1">
+                            Feria de Alimentos
+                        </span>
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs">
+                            Feria de Tecnología
+                        </span>
+                    </td>
+                    <td class="px-4 py-4">
+                        <div class="flex flex-col md:flex-row items-center justify-center gap-2">
+                            <a href="#" title="Ver"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-teal-600 text-white hover:bg-teal-500 transition">
+                                <i class="fas fa-eye text-sm"></i>
+                            </a>
+                            <a href="" title="Editar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-yellow-500 text-white hover:bg-yellow-400 transition">
+                                <i class="fas fa-pen text-sm"></i>
+                            </a>
+                            <a href="#" title="Eliminar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-red-500 text-white hover:bg-red-400 transition">
+                                <i class="fas fa-trash text-sm"></i>
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection

--- a/resources/views/fairs/_form.blade.php
+++ b/resources/views/fairs/_form.blade.php
@@ -1,0 +1,33 @@
+@php($readonly = $readonly ?? false)
+
+<div class="space-y-4">
+    <div>
+        <label class="block text-gray-300 mb-1">Nombre</label>
+        <input type="text" name="nombre" value="{{ old('nombre', 'Parque de Ferias de Managua') }}" placeholder="e.g.: Feria de Verano" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2"/>
+    </div>
+
+    <div>
+        <label class="block text-gray-300 mb-1">Fecha</label>
+        <input type="date" name="fecha" value="{{ old('fecha', '2025-05-25') }}" placeholder="e.g. 2025-05-25" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2 filter [&::-webkit-calendar-picker-indicator]:invert"/>
+    </div>
+
+    <div>
+        <label class="block text-gray-300 mb-1">Lugar</label>
+        <input type="text" name="lugar" value="{{ old('lugar', 'Pista Suburbana, Barrio San Juan') }}" placeholder="e.g.: Pista Suburbuna..." class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2"/>
+    </div>
+
+    <div>
+        <label class="block text-gray-300 mb-1">Descripción</label>
+        <textarea name="descripcion" rows="4" placeholder="e.g. Evento para promover productos locales" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2">Evento para emprendedores locales con productos artesanales, alimentos y más.</textarea>
+    </div>
+
+    <div>
+        <label class="block text-gray-300 mb-1">Emprendedores</label>
+        <select name="emprendedores[]" multiple placeholder="e.g.: Seleccione los emprendedores participantes" class="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded px-3 py-2">
+            <!-- Ejemplo temporal de opciones -->
+            <option value="1" selected>Juan Pérez</option>
+            <option value="2">María López</option>
+            <option value="3">José Martínez</option>
+        </select>
+    </div>
+</div>

--- a/resources/views/fairs/create.blade.php
+++ b/resources/views/fairs/create.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="bg-slate-800 min-h-screen px-20 py-8">
+    <h1 class="text-2xl font-semibold text-gray-100 mb-6">
+        {{ __('Registrar nueva feria') }}
+    </h1>
+
+    <form action="#" method="POST" class="bg-gray-900 shadow-lg rounded-lg p-6 space-y-6">
+        @include('fairs._form')
+
+        <div class="flex items-center justify-end gap-2">
+            <button type="submit"
+                    class="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500 transition">
+                <i class="fa-solid fa-check mr-1"></i> {{ __('Guardar') }}
+            </button>
+            <a href="{{ route('fairs.index') }}"
+               class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 transition">
+                <i class="fa-solid fa-xmark mr-1"></i> {{ __('Cancelar') }}
+            </a>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/fairs/edit.blade.php
+++ b/resources/views/fairs/edit.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="bg-slate-800 min-h-screen px-20 py-8">
+    <h1 class="text-2xl font-semibold text-gray-100 mb-6">
+        Editar Feria
+    </h1>
+
+    <form action="#" method="POST"
+          class="bg-gray-900 shadow-lg rounded-lg p-6 space-y-6">
+        @method('PUT')
+
+        @include('fairs._form')
+
+        <div class="flex items-center justify-end gap-2">
+            <button type="submit"
+                    class="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500 transition">
+                Actualizar
+            </button>
+            <a href="#"
+               class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500 transition">
+                Cancelar
+            </a>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/fairs/index.blade.php
+++ b/resources/views/fairs/index.blade.php
@@ -1,0 +1,97 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="bg-slate-800 min-h-screen px-20 py-8">
+    <h1 class="text-2xl font-semibold text-gray-100 mb-6">
+        {{ __('Ferias registradas') }}
+    </h1>
+
+    <a href="{{ route('fairs.create') }}"
+       class="mb-4 inline-block px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-500 transition duration-200">
+        <i class="fa-solid fa-plus mr-2"></i>
+        {{ __('Nueva feria') }}
+    </a>
+
+    <div class="overflow-x-auto bg-gray-900 shadow-lg rounded-lg">
+        <table class="min-w-full divide-y divide-gray-800">
+            <thead class="bg-gray-800 text-gray-300">
+                <tr>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Nombre</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Fecha</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Lugar</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Descripción</th>
+                    <th class="px-6 py-3 text-left text-sm font-semibold">Emprendedores</th>
+                    <th class="px-4 py-3 text-center text-sm font-semibold">Acciones</th>
+                </tr>
+            </thead>
+            <tbody class="bg-gray-900 divide-y divide-gray-800">
+                <!-- Ejemplo de fila 1 -->
+                <tr class="even:bg-gray-800">
+                    <td class="px-6 py-4 text-gray-300">Parque de Ferias de Managua</td>
+                    <td class="px-6 py-4 text-gray-300">13-05-25</td>
+                    <td class="px-6 py-4 text-gray-300">Pista Suburbana</td>
+                    <td class="px-6 py-4 text-gray-300">
+                        {{ Str::limit('Evento para emprendedores locales con productos artesanales, alimentos, tecnología y más en la comunidad.', 50) }}
+                    </td>
+                    <td class="px-6 py-4 text-gray-300">
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs mr-1">
+                            Juan Pérez
+                        </span>
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs">
+                            María López
+                        </span>
+                    </td>
+                    <td class="px-4 py-4">
+                        <div class="flex flex-col md:flex-row items-center justify-center gap-2">
+                            <button title="Ver"class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-teal-600 text-white hover:bg-teal-500 transition">
+                                <i class="fas fa-eye text-sm"></i>
+                            </button>
+                            <a href="{{route('fairs.edit')}}" title="Editar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-yellow-500 text-white hover:bg-yellow-400 transition">
+                                <i class="fas fa-pen text-sm"></i>
+                            </a>
+                            <a href="#" title="Eliminar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-red-500 text-white hover:bg-red-400 transition">
+                                <i class="fas fa-trash text-sm"></i>
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+                <!-- Ejemplo de fila 2 -->
+                <tr>
+                    <td class="px-6 py-4 text-gray-300">Feria de Tecnología</td>
+                    <td class="px-6 py-4 text-gray-300">20-06-25</td>
+                    <td class="px-6 py-4 text-gray-300">Centro Cultural Managua</td>
+                    <td class="px-6 py-4 text-gray-300">
+                         {{ Str::limit('Showcase de startups y proyectos tech de la ciudad.', 50)}}
+                    </td>
+                    <td class="px-6 py-4 text-gray-300">
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs mr-1">
+                            José Martínez
+                        </span>
+                        <span class="inline-block px-2 py-1 bg-gray-700 text-gray-200 rounded text-xs">
+                            Carolina Ruiz
+                        </span>
+                    </td>
+                    <td class="px-4 py-4">
+                        <div class="flex flex-col md:flex-row items-center justify-center gap-2">
+                            <a href="#" title="Ver"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-teal-600 text-white hover:bg-teal-500 transition">
+                                <i class="fas fa-eye text-sm"></i>
+                            </a>
+                            <a href="#" title="Editar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-yellow-500 text-white hover:bg-yellow-400 transition">
+                                <i class="fas fa-pen text-sm"></i>
+                            </a>
+                            <a href="#" title="Eliminar"
+                               class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-red-500 text-white hover:bg-red-400 transition">
+                                <i class="fas fa-trash text-sm"></i>
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,16 +16,23 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
     <link href="https://fonts.bunny.net/css?family=lora:400&display=swap" rel="stylesheet"/>
-
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://getbootstrap.com/docs/5.3/assets/css/docs.css" rel="stylesheet">
     <!-- Tailwind + Vite -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 
-    <!-- Kit de Íconos de Font Awesome -->
+    <!-- Librerías de: Kit de Íconos de Font Awesome, Alpine.js para ventanas modales y Bundle JS de Bootstrap para componententes interactivos -->
     <script defer src="https://kit.fontawesome.com/2af02d949f.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-…" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>
 
 <body class="font-sans antialiased">
     <div class="bg-gray-100 dark:bg-gray-900">
+        <!-- Se mostrará la barra de navegación siempre y cuando no se esté en la vista de welcome.blade.php -->
+        @if(!request()->is('/'))
+            @include('layouts.navigation')
+        @endif
 
         <main>
             @yield('content')

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,42 +1,50 @@
-<nav class="navbar bg-[#111827] text-gray-200 shadow-md navbar-expand-md">
+<nav class="navbar !bg-[#111827] text-gray-200 shadow-md navbar-expand-md">
     <div class="container-fluid px-4 py-4">
+        <a href="{{url('/')}}" class="navbar-brand flex items-center font-semibold text-white hover:text-gray-300">
+            <!-- Logo / Ícono de la Web -->
+            <div class="inline-flex items-center justify-center bg-gradient-to-tr from-slate-800 to-slate-700 p-2 rounded-full">
+                <i class="fa-solid fa-store text-xl text-gray-200"></i>
+            </div>
+            
+            <!-- Texto al lado derecho del logo/ícono -->
+            <span class="ml-2">ManaguaFairs</span>
+        </a>
 
-    <a href="#" class="navbar-brand flex items-center font-semibold text-white hover:text-gray-300">
-        <!-- Logo / Ícono de la Web -->
-        <div class="inline-flex items-center justify-center bg-gradient-to-tr from-slate-800 to-slate-700 p-2 rounded-full">
-            <i class="fa-solid fa-store text-xl text-gray-200"></i>
-        </div>
-        
-        <!-- Texto al lado derecho del logo/ícono -->
-        <span class="ml-2">ManaguaFairs</span>
-    </a>
+        <!-- Botón de menú hamburguesa para móviles. Despliegue Offcanvas -->
+        <button class="navbar-toggler navbar-dark" type="button" data-bs-toggle="offcanvas"
+            data-bs-target="#navbarOffcanvas" aria-controls="navbarOffcanvas" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
 
-    <!-- Botón de menú hamburguesa para móviles. Despliegue Offcanvas -->
-    <button class="navbar-toggler navbar-dark" type="button" data-bs-toggle="offcanvas"
-        data-bs-target="#navbarOffcanvas" aria-controls="navbarOffcanvas" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <!-- Menú para escritorio | Menú Offcanvas para móviles -->
-    <div class="offcanvas offcanvas-end !bg-[#111827] !text-white" id="navbarOffcanvas" tabindex="-1" aria-labelledby="offcanvasNavbarLabel">
-        <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Menú</h5>
-            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        <!-- Menú para escritorio | Menú Offcanvas para móviles -->
+        <div class="offcanvas offcanvas-end !bg-[#111827] !text-white" id="navbarOffcanvas" tabindex="-1" aria-labelledby="offcanvasNavbarLabel">
+            <div class="offcanvas-header py-6 justify-between">
+                <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Menú</h5>
+                <button type="button" class="flex items-center justify-center w-8 h-8 p-1 rounded bg-slate-800 hover:bg-slate-700" data-bs-dismiss="offcanvas" aria-label="Cerrar menú">
+                    <i class="fa-solid fa-xmark text-white"></i>
+                </button>
+            </div>
+            
+            <div class="offcanvas-body">
+                <ul class="navbar-nav justify-end flex-grow-1 pe-3">
+                    <li class="nav-item">
+                        <a href="{{ route('fairs.index') }}" class="nav-link px-3 py-2 rounded transition duration-200
+                            {{ request()->routeIs('fairs.*')
+                                ? 'bg-gray-800 text-teal-300'
+                                : 'text-white hover:!bg-gray-800' }}">
+                                {{ __('Ferias') }}
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="{{ route('entrepreneurs.index') }}" class="nav-link px-3 py-2 rounded transition duration-200
+                            {{ request()->routeIs('entrepreneurs.*')
+                                ? 'bg-gray-800 text-teal-300'
+                                : 'text-white hover:!bg-gray-800' }}">
+                                {{ __('Emprendedores') }}
+                        </a>
+                    </li>
+                </ul>
+            </div>
         </div>
-        <div class="offcanvas-body">
-        <ul class="navbar-nav justify-end flex-grow-1 pe-3">
-            <li class="nav-item">
-            <a href="#" class="nav-link px-3 py-2 text-white rounded transition duration-200 bg-transparent hover:!bg-gray-800">
-                Ferias
-            </a>
-            </li>
-            <li class="nav-item">
-            <a href="#" class="nav-link px-3 py-2 text-white rounded transition duration-200 bg-transparent hover:!bg-gray-800">
-                Emprendedores
-            </a>
-            </li>
-        </ul>
-        </div>
-    </div>
     </div>
 </nav>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,12 +2,12 @@
 
 @section('content')
 <section id="heroSection"
-    class="min-h-screen overflow-hidden flex flex-col items-center justify-center text-center px-4 py-8 md:px-6 md:py-0 bg-gray-100 dark:bg-gray-900 text-white">
+    class="min-h-screen overflow-hidden flex flex-col items-center justify-center text-center px-4 py-8 md:px-6 md:py-0 bg-[#111827] text-white">
 
     <!-- Logo (ícono) representativo del sitio web -->
     <div class="mb-2 sm:mb-4">
         <div class="inline-flex items-center justify-center bg-gradient-to-tr from-slate-800 to-slate-700 p-4 rounded-full">
-            <i class="fa-solid fa-store text-4xl text-gray-200"></i>
+            <i class="fa-solid fa-store text-3xl text-gray-200"></i>
         </div>
     </div>
 
@@ -21,12 +21,12 @@
 
     <!-- Botones de gestión de ferias y emprendedores -->
     <div class="mt-6 flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="#" class="w-48 px-6 py-3 bg-[#115e59] rounded-lg hover:bg-opacity-70 text-white font-medium transition duration-200">
-            Ver Ferias
+        <a href="{{ route('fairs.index') }}" class="w-48 px-6 py-3 bg-[#115e59] rounded-lg hover:bg-opacity-70 text-white font-medium transition duration-200">
+            {{ __('Ver Ferias') }}
         </a>
 
-        <a href="#" class="w-48 px-6 py-3 bg-[#3730a3] rounded-lg hover:bg-opacity-70 text-white font-medium transition duration-200">
-            Ver Emprendedores
+        <a href="{{ route('entrepreneurs.index') }}" class="w-48 px-6 py-3 bg-[#3730a3] rounded-lg hover:bg-opacity-70 text-white font-medium transition duration-200">
+            {{ __('Ver Emprendedores') }}
         </a>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,14 +7,25 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
-
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
+
+// Stub para vistas de ferias y emprendedores
+Route::view('/fairs', 'fairs.index')
+     ->name('fairs.index');
+Route::view('/fairs/create', 'fairs.create')
+     ->name('fairs.create');
+Route::view('/fairs/edit', 'fairs.edit')
+     ->name('fairs.edit');
+
+Route::view('/entrepreneurs', 'entrepreneurs.index')
+     ->name('entrepreneurs.index');
+Route::view('/entrepreneurs/create', 'entrepreneurs.create')
+     ->name('entrepreneurs.create');
+Route::view('/entrepreneurs/edit', 'entrepreneurs.edit')
+     ->name('entrepreneurs.edit');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
The following PR delivers:

- A full set of Blade views for fairs and entrepreneurs (index, create, edit) plus a shared _form partial to reuse form fields across create/edit pages (and future show modals). These layouts are populated with static placeholder data to showcase the design and will be wired up to real models and controllers once merged into develop.
- Minor UI, layout and routing tweaks for consistency.


